### PR TITLE
Bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ license = "MIT"
 exclude = ["*.sh"]
 
 [dependencies]
-nalgebra = "~0.21.0"
-statrs = "~0.12.0"
+nalgebra = "~0.25.0"
+statrs = "~0.13.0"
 
 [dev-dependencies]
 quickcheck = "~0.8.2"


### PR DESCRIPTION
I executed `cargo build` and `cargo test` to verify nothing is broken.
I checked changes between versions of the dependencies and it looks like there were no breaking changes.