### PR TITLE
Bump nalgebra version in response to RUSTSEC-2021-0070

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 exclude = ["*.sh"]
 
 [dependencies]
-nalgebra = "~0.25.0"
+nalgebra = "~0.27.1"
 statrs = "~0.13.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Advisory page with more context: https://rustsec.org/advisories/RUSTSEC-2021-0070

I verified the test suite passes, but otherwise didn't do any additional verification.